### PR TITLE
XCURSOR_PATH is now directed to host path - fixes #4

### DIFF
--- a/snap/local/custom-wrapper
+++ b/snap/local/custom-wrapper
@@ -3,6 +3,6 @@
 export XDG_CONFIG_HOME="$SNAP_REAL_HOME/.config"
 export XDG_DATA_HOME="$SNAP_REAL_HOME/.local/share"
 
-export XCURSOR_PATH="/usr/share/icons"
+export XCURSOR_PATH="/usr/share/icons:$XCURSOR_PATH"
 
 exec "$@"

--- a/snap/local/custom-wrapper
+++ b/snap/local/custom-wrapper
@@ -3,4 +3,6 @@
 export XDG_CONFIG_HOME="$SNAP_REAL_HOME/.config"
 export XDG_DATA_HOME="$SNAP_REAL_HOME/.local/share"
 
+export XCURSOR_PATH="/usr/share/icons"
+
 exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ apps:
         command: bin/alacritty
         command-chain:
             - bin/desktop-launch
-            - bin/xdg-wrapper
+            - bin/custom-wrapper
         common-id: io.alacritty.Alacritty
         desktop: usr/share/applications/Alacritty.desktop
         environment:
@@ -40,11 +40,11 @@ parts:
         build-attributes:
             - no-patchelf
 
-    xdg-wrapper:
+    custom-wrapper:
         plugin: dump
         source: snap/local/
         organize:
-            xdg-wrapper: bin/
+            custom-wrapper: bin/
 
     alacritty:
         plugin: rust


### PR DESCRIPTION
The script in `snapcraft-desktop-helpers` repo defines the below lines which causes the snap to show the ugly, pixelated cursor icons:

```
# Set XCursors path
export XCURSOR_PATH=$RUNTIME/usr/share/icons
prepend_dir XCURSOR_PATH $SNAP/data-dir/icons
```

Since classic snaps work as if they're directly on the host system, these folders don't exist and causes the issue. This change sets the snap to work with system themes. (we can maybe add the icons directory within local user's home in the future)